### PR TITLE
Update tab_containter_load1time.dart

### DIFF
--- a/lib/tab_containter_load1time.dart
+++ b/lib/tab_containter_load1time.dart
@@ -55,7 +55,7 @@ class _TabContainerLoad1TimeState extends State<TabContainerLoad1Time> {
     return MaterialApp(
       color: Colors.yellow,
       home: Scaffold(
-        body: IndexedStack(index: tabIndex, children: listScreens),
+        body: IndexedStack(index: listScreensIndex.indexOf(tabIndex), children: listScreens),
         bottomNavigationBar: BottomNavigationBar(
             currentIndex: tabIndex,
             onTap: _selectedTab,


### PR DESCRIPTION
Index issue when you select the last tab can be fixed by replacing the below line 

body: IndexedStack(index: tabIndex, children: listScreens),

with

body: IndexedStack(index: listScreensIndex.indexOf(tabIndex), children: listScreens),